### PR TITLE
Replace apt -> apt-get, install git to support provisioning 

### DIFF
--- a/scripts/ansible.sh
+++ b/scripts/ansible.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -eux
 
 # Install Ansible repository.
-apt -y update && apt-get -y upgrade
-apt -y install software-properties-common
+apt-get -y update && apt-get -y upgrade
+apt-get -y install software-properties-common
 apt-add-repository ppa:ansible/ansible
 
 # Install Ansible.
-apt -y update
-apt -y install ansible
+apt-get -y update
+apt-get -y install ansible git


### PR DESCRIPTION
using roles from git repositories not only from Ansible Galaxy.

This pull request partially replace the pull request #22