### PR TITLE
Fix vagrant user not being created in Centos 8

### DIFF
--- a/centos8/http/ks.cfg
+++ b/centos8/http/ks.cfg
@@ -17,7 +17,6 @@ auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
 eula --agreed
 services --enabled=NetworkManager,sshd
-user --name=vagrant --plaintext --password=vagrant --groups=vagrant,wheel
 reboot
 
 %packages --ignoremissing --excludedocs
@@ -71,6 +70,11 @@ yum update -y
 
 # update root certs
 wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+
+# Add vagrant user (user directive isn't working for some reason).
+useradd vagrant
+echo "vagrant" | passwd vagrant --stdin
+usermod -a -G wheel vagrant
 
 # sudo
 yum install -y sudo


### PR DESCRIPTION
https://github.com/geerlingguy/packer-centos-8/commit/8a598ea4e41b5d99f4369f866852dfedd8ca06ef

Comes from the original packer centos 8 repo you did but somehow got lost when ported in here. Locally at least I get the vagrant user missing without porting this fix