### PR TITLE
Fix/outdated iso

### DIFF
--- a/centos7/box-config.json
+++ b/centos7/box-config.json
@@ -35,7 +35,7 @@
         "http://mirrors.mit.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso"
       ],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
+      "iso_checksum": "659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/centos7/box-config.json
+++ b/centos7/box-config.json
@@ -31,8 +31,8 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "CentOS-7-x86_64-Minimal-1908.iso",
-        "http://mirrors.mit.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso"
+        "CentOS-7-x86_64-Minimal-2003.iso",
+        "http://mirrors.mit.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso"
       ],
       "iso_checksum_type": "sha256",
       "iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",


### PR DESCRIPTION
Initial CentOS7 ISO url http://mirrors.mit.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso  is not available anymore. 

![image](https://user-images.githubusercontent.com/25921736/80541238-1a303000-89ab-11ea-911f-7a47e9091207.png)

## This PR contains
- ISO url update to the latest available from the same mirror: http://mirrors.mit.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso.
- Checksum update for the new ISO.
