### PR TITLE
Fix KS vagrant user creation

### DIFF
--- a/centos8/http/ks.cfg
+++ b/centos8/http/ks.cfg
@@ -17,7 +17,7 @@ auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
 eula --agreed
 services --enabled=NetworkManager,sshd
-#user --name=vagrant --plaintext --password=vagrant --groups=vagrant,wheel
+user --name=vagrant --plaintext --password=vagrant --groups=wheel
 reboot
 
 %packages --ignoremissing --excludedocs
@@ -71,11 +71,6 @@ yum update -y
 
 # update root certs
 wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
-
-# Add vagrant user (user directive isn't working for some reason).
-useradd vagrant
-echo "vagrant" | passwd vagrant --stdin
-usermod -a -G wheel vagrant
 
 # sudo
 yum install -y sudo


### PR DESCRIPTION
It fails silently, but KS can't create the `vagrant` user because the KS command couldn't add the user to the group `vagrant` that didn't exist yet. KS will automagically create the `vagrant` group as part of creating the user.

https://docs.centos.org/en-US/8-docs/advanced-install/assembly_kickstart-commands-and-options-reference/#user_kickstart-commands-for-system-configuration