### PR TITLE
Fix identical machine-ids causing dhcp servers to to use same IPs

### DIFF
--- a/debian10/scripts/cleanup.sh
+++ b/debian10/scripts/cleanup.sh
@@ -8,6 +8,11 @@ apt-get remove python-pip python-dev
 apt autoremove
 apt update
 
+#  Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
 

--- a/debian9/scripts/cleanup.sh
+++ b/debian9/scripts/cleanup.sh
@@ -8,6 +8,11 @@ apt-get remove python-pip python-dev
 apt autoremove
 apt update
 
+#  Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
 

--- a/ubuntu1804/scripts/cleanup.sh
+++ b/ubuntu1804/scripts/cleanup.sh
@@ -8,6 +8,11 @@ apt-add-repository --remove ppa:ansible/ansible
 apt autoremove
 apt update
 
+#  Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
 

--- a/ubuntu2004/scripts/cleanup.sh
+++ b/ubuntu2004/scripts/cleanup.sh
@@ -8,6 +8,11 @@ apt-add-repository --remove ppa:ansible/ansible
 apt autoremove
 apt update
 
+#  Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
 


### PR DESCRIPTION
See https://github.com/geerlingguy/packer-drupal-vm/pull/4 for explanation.

I haven't actually tested this on the Debian boxes but in theory this should be needed since Jessie when systemd became the default. [Source](https://lists.debian.org/debian-devel/2019/08/msg00262.html)

Also dug out this man page for Debian9 to make sure. https://manpages.debian.org/stretch/systemd/systemd-machine-id-setup.1.en.html