### PR TITLE
Switched from http to https for ca-cert download

### DIFF
--- a/centos7/http/ks.cfg
+++ b/centos7/http/ks.cfg
@@ -72,7 +72,7 @@ rsync
 yum update -y
 
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+wget -O/etc/pki/tls/certs/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
 
 # sudo
 yum install -y sudo

--- a/centos8/http/ks.cfg
+++ b/centos8/http/ks.cfg
@@ -70,7 +70,7 @@ rsync
 yum update -y
 
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+wget -O/etc/pki/tls/certs/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
 
 # sudo
 yum install -y sudo


### PR DESCRIPTION
Since it is such a sensitive file, it probably makes sense to download it via https.
