### PR TITLE
Update: safer cert retrieval for Centos 7 and 8

### DIFF
--- a/centos7/http/ks.cfg
+++ b/centos7/http/ks.cfg
@@ -72,7 +72,9 @@ rsync
 yum update -y
 
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+wget -O/tmp/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+
+openssl x509 -text -in /tmp/ca-bundle.crt > /dev/null && mv /tmp/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # sudo
 yum install -y sudo

--- a/centos8/http/ks.cfg
+++ b/centos8/http/ks.cfg
@@ -70,7 +70,9 @@ rsync
 yum update -y
 
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+wget -O/tmp/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+
+openssl x509 -text -in /tmp/ca-bundle.crt > /dev/null && mv /tmp/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # sudo
 yum install -y sudo


### PR DESCRIPTION
Tries to download the certs via https, doesn't change the original file if the download fails and the temporary file is not valid.
