### PR TITLE
Convert shared/requirements.yml to newer file format

### DIFF
--- a/shared/requirements.yml
+++ b/shared/requirements.yml
@@ -1,4 +1,5 @@
 ---
-- src: geerlingguy.packer_rhel
-- src: geerlingguy.packer-debian
-- src: geerlingguy.nfs
+roles:
+  - geerlingguy.packer_rhel
+  - geerlingguy.packer-debian
+  - geerlingguy.nfs


### PR DESCRIPTION
Recent Packer versions do not support the requirements file format from Ansible 2.8 and before. There's a [bug report](https://github.com/hashicorp/packer-plugin-ansible/issues/111) for HashiCorp's Ansible plugin. Vagrant boxes can be built again by converting shared/requirements.yml to the current file format. Tested with Packer 1.8.5 and the boxes for CentOS 7, Rocky Linux 8 and Ubuntu 20.04. This change fixes #96.